### PR TITLE
Use web auth build flag names

### DIFF
--- a/include/config.hpp
+++ b/include/config.hpp
@@ -4,6 +4,10 @@
 extern const char* WIFI_SSID;
 extern const char* WIFI_PASSWORD;
 
+// Web authentication
+extern const char* WEB_AUTH_USERNAME;
+extern const char* WEB_AUTH_PASSWORD;
+
 // ntfy configuration
 extern const char* NTFY_SERVER;
 extern const char* NTFY_TOPIC;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -10,6 +10,8 @@
 //   -DNTFY_USERNAME_VALUE=\"user\"
 //   -DNTFY_PASSWORD_VALUE=\"pass\"
 //   -DDISCORD_WEBHOOK_URL_VALUE=\"https://discord.com/api/webhooks/...\"
+//   -DWEB_AUTH_USERNAME_VALUE=\"admin\"
+//   -DWEB_AUTH_PASSWORD_VALUE=\"changeme\"
 
 #ifndef WIFI_SSID_VALUE
 #define WIFI_SSID_VALUE "xxx"
@@ -17,6 +19,14 @@
 
 #ifndef WIFI_PASSWORD_VALUE
 #define WIFI_PASSWORD_VALUE "xxx"
+#endif
+
+#ifndef WEB_AUTH_USERNAME_VALUE
+#define WEB_AUTH_USERNAME_VALUE ""
+#endif
+
+#ifndef WEB_AUTH_PASSWORD_VALUE
+#define WEB_AUTH_PASSWORD_VALUE ""
 #endif
 
 #ifndef NTFY_SERVER_VALUE
@@ -73,6 +83,9 @@
 
 const char* WIFI_SSID = WIFI_SSID_VALUE;
 const char* WIFI_PASSWORD = WIFI_PASSWORD_VALUE;
+
+const char* WEB_AUTH_USERNAME = WEB_AUTH_USERNAME_VALUE;
+const char* WEB_AUTH_PASSWORD = WEB_AUTH_PASSWORD_VALUE;
 
 const char* NTFY_SERVER = NTFY_SERVER_VALUE;
 const char* NTFY_TOPIC = NTFY_TOPIC_VALUE;


### PR DESCRIPTION
## Summary
- switch web authentication defaults to WEB_AUTH_* build flag names
- document the new auth build flags alongside other PlatformIO overrides
- rename web auth configuration variables to WEB_AUTH_* for consistency

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6928267e1e5083328752bdd6b556d057)